### PR TITLE
update RenderResultAsJsonValve.java

### DIFF
--- a/webx/turbine/src/main/java/com/alibaba/citrus/turbine/pipeline/valve/RenderResultAsJsonValve.java
+++ b/webx/turbine/src/main/java/com/alibaba/citrus/turbine/pipeline/valve/RenderResultAsJsonValve.java
@@ -100,7 +100,10 @@ public class RenderResultAsJsonValve extends AbstractInputOutputValve {
             }
 
             PrintWriter out = response.getWriter();
-            String jsonResult = JSON.toJSONString(resultObject);
+            String jsonResult = JSON
+						.toJSONString(
+								resultObject,
+								new SerializerFeature[] { SerializerFeature.WriteTabAsSpecial });
 
             if (outputAsJson) {
                 out.print(jsonResult);


### PR DESCRIPTION
When resultObject contains field that has a value which contains '\t',ajax request failed. So when invoke JSON.toJSONString, escape '\t'.
